### PR TITLE
Fix bugs in trap/vectors.S on amd64 & i386

### DIFF
--- a/ucore/src/kern-ucore/arch/amd64/trap/vectors.S
+++ b/ucore/src/kern-ucore/arch/amd64/trap/vectors.S
@@ -47,6 +47,7 @@ vector8:
   jmp __alltraps
 .globl vector9
 vector9:
+  pushq $0
   pushq $9
   jmp __alltraps
 .globl vector10

--- a/ucore/src/kern-ucore/arch/i386/trap/vectors.S
+++ b/ucore/src/kern-ucore/arch/i386/trap/vectors.S
@@ -47,6 +47,7 @@ vector8:
   jmp __alltraps
 .globl vector9
 vector9:
+  pushl $0
   pushl $9
   jmp __alltraps
 .globl vector10


### PR DESCRIPTION
Interrupt 9 on amd64/i386 has no error code.
Reference: 6.15 of Intel® 64 and IA-32 Architectures Software Developer’s Manual