### PR TITLE
fixed a bug of proc.c, and made a small change of ucore_run

### DIFF
--- a/ucore/src/kern-ucore/process/proc.c
+++ b/ucore/src/kern-ucore/process/proc.c
@@ -953,9 +953,9 @@ int program_count, struct mm_struct *mm, int fd, off_t bias)
     start = ROUNDDOWN(start, PGSIZE);
     end = ROUNDUP(end, PGSIZE);
     int program_page_count = (end - start) / PGSIZE;
-    pte_t* pte = get_pte(mm->pgdir, start, 0);
     for(int i = 0; i < program_page_count; i++) {
-      ptep_set_perm(&pte[i], ptep_get_perm(&pte[i], ~(PTE_W | PTE_U)) | perm);
+      pte_t* pte = get_pte(mm->pgdir, start +PGSIZE*i, 0);
+      ptep_set_perm(pte, ptep_get_perm(pte, ~(PTE_W | PTE_U)) | perm);
     }
   }
   return 0;

--- a/ucore/uCore_run
+++ b/ucore/uCore_run
@@ -147,7 +147,6 @@ case $UCONFIG_ARCH in
         exec $QEMU -m 512 \
             -hda $BUILD_DIR/kernel.img$TEST_POSTFIX \
             -drive file=$BUILD_DIR/sfs.img$TEST_POSTFIX,media=disk,cache=writeback,index=2 \
-            -drive file=yaffs_disk.img,media=disk,cache=writeback,index=3 \
             -net nic,model=e1000 -net dump,file=/tmp/vm0.pcap \
             -net user,id=mynet0,net=192.168.76.0/24,hostfwd=tcp::10022-:22 \
             $EXTRA_OPT


### PR DESCRIPTION
在我们的工作中需要在ucore上运行一个较大的用户程序（约几十MB），但是在运行的过程中发现proc.c的proc_elf_set_permission函数中存在bug，即当用户程序所占用的pte个数大于PGSIZE时，原实现并未建立新的pte项，将导致数组越界，破坏正常数据。现已修复了这个bug。

ucore_run脚本中也存在一个bug，即在调用qemu运行ucore的时候，加入了一个不存在的硬盘镜像（yaffs），现已将这一行代码删除。

bug发现者：王纪霆，匡正非 #