### PR TITLE
Fixed shmem bug in do_pgfault, vmm.c. Changed pa2page to pte2page

### DIFF
--- a/ucore/src/kern-ucore/mm/vmm.c
+++ b/ucore/src/kern-ucore/mm/vmm.c
@@ -1025,7 +1025,7 @@ int do_pgfault(struct mm_struct *mm, machine_word_t error_code, uintptr_t addr)
 			}
 			unlock_shmem(vma->shmem);
 			if (ptep_present(sh_ptep)) {
-				page_insert(mm->pgdir, pa2page(*sh_ptep), addr,
+				page_insert(mm->pgdir, pte2page(*sh_ptep), addr,
 					    perm);
 			} else {
 #ifdef UCONFIG_SWAP


### PR DESCRIPTION
很明显这里把pte变为page需要调用pte2page。
在x86里面，由于pte和pa的长度都为32bit或64bit，pa2page与pte2page是等价的，所以没有暴露这个bug。
而在risc-v里，pte和物理地址的长度不同，因此这个问题暴露得尤为明显。